### PR TITLE
Start adding stdio support to soup-cli

### DIFF
--- a/experiments/soup-app-demo/.cargo/config.toml
+++ b/experiments/soup-app-demo/.cargo/config.toml
@@ -4,6 +4,3 @@ runner = "probe-run --chip nRF52840_xxAA"
 
 [build]
 target = "thumbv7em-none-eabi"
-
-[env]
-DEFMT_LOG = "trace"

--- a/experiments/soup-app-demo/Cargo.lock
+++ b/experiments/soup-app-demo/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 [[package]]
 name = "embassy-cortex-m"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -163,15 +163,15 @@ dependencies = [
  "embassy-executor",
  "embassy-hal-common",
  "embassy-macros",
- "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
+ "embassy-sync",
 ]
 
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
- "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
+ "embassy-sync",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-alpha.9",
  "embedded-hal-async",
@@ -183,7 +183,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -197,12 +197,12 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
  "num-traits",
 ]
@@ -210,7 +210,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -221,22 +221,22 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 
 [[package]]
 name = "embassy-net-driver-channel"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
- "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
+ "embassy-sync",
 ]
 
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -245,7 +245,7 @@ dependencies = [
  "embassy-cortex-m",
  "embassy-embedded-hal",
  "embassy-hal-common",
- "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
+ "embassy-sync",
  "embassy-time",
  "embassy-usb-driver",
  "embedded-hal 0.2.7",
@@ -263,19 +263,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
-dependencies = [
- "cfg-if",
- "critical-section",
- "embedded-io",
- "futures-util",
- "heapless",
-]
-
-[[package]]
-name = "embassy-sync"
-version = "0.1.0"
-source = "git+https://github.com/jamesmunns/embassy?rev=4b5581be96f549cbab2f464f4eb5167ee4ab5ed1#4b5581be96f549cbab2f464f4eb5167ee4ab5ed1"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -287,12 +275,12 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
  "critical-section",
- "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
+ "embassy-sync",
  "embedded-hal 0.2.7",
  "futures-util",
  "heapless",
@@ -301,11 +289,11 @@ dependencies = [
 [[package]]
 name = "embassy-usb"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver-channel",
- "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
+ "embassy-sync",
  "embassy-usb-driver",
  "heapless",
  "ssmarshal",
@@ -315,7 +303,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
+source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 
 [[package]]
 name = "embedded-hal"
@@ -356,9 +344,9 @@ checksum = "156d7a2fdd98ebbf9ae579cbceca3058cff946e13f8e17b90e3511db0508c723"
 
 [[package]]
 name = "embedded-storage-async"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff04af74e47e9bb4315bd7aa2b01f3d1b05f33c03a6c4e9c3b20e9ce9cd8d79"
+checksum = "052997a894670d0cde873faa7405bc98e2fd29f569d2acd568561bc1c396b35a"
 dependencies = [
  "embedded-storage",
 ]
@@ -661,9 +649,10 @@ dependencies = [
  "embassy-executor",
  "embassy-futures",
  "embassy-nrf",
- "embassy-sync 0.1.0 (git+https://github.com/jamesmunns/embassy?rev=4b5581be96f549cbab2f464f4eb5167ee4ab5ed1)",
+ "embassy-sync",
  "embassy-time",
  "embassy-usb",
+ "heapless",
  "panic-reset",
  "postcard",
  "soup-icd",

--- a/experiments/soup-app-demo/Cargo.lock
+++ b/experiments/soup-app-demo/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
  "embassy-executor",
  "embassy-hal-common",
  "embassy-macros",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ name = "embassy-embedded-hal"
 version = "0.1.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
 dependencies = [
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-alpha.9",
  "embedded-hal-async",
@@ -230,7 +230,7 @@ source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a2
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ dependencies = [
  "embassy-cortex-m",
  "embassy-embedded-hal",
  "embassy-hal-common",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
  "embassy-time",
  "embassy-usb-driver",
  "embedded-hal 0.2.7",
@@ -273,6 +273,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-sync"
+version = "0.1.0"
+source = "git+https://github.com/jamesmunns/embassy?rev=4b5581be96f549cbab2f464f4eb5167ee4ab5ed1#4b5581be96f549cbab2f464f4eb5167ee4ab5ed1"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "embedded-io",
+ "futures-util",
+ "heapless",
+]
+
+[[package]]
 name = "embassy-time"
 version = "0.1.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525#18fe398673f55b07159d01a230910bb9689c1525"
@@ -280,7 +292,7 @@ dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
  "critical-section",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
  "embedded-hal 0.2.7",
  "futures-util",
  "heapless",
@@ -293,7 +305,7 @@ source = "git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a2
 dependencies = [
  "embassy-futures",
  "embassy-net-driver-channel",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/embassy-rs/embassy?rev=18fe398673f55b07159d01a230910bb9689c1525)",
  "embassy-usb-driver",
  "heapless",
  "ssmarshal",
@@ -649,7 +661,7 @@ dependencies = [
  "embassy-executor",
  "embassy-futures",
  "embassy-nrf",
- "embassy-sync",
+ "embassy-sync 0.1.0 (git+https://github.com/jamesmunns/embassy?rev=4b5581be96f549cbab2f464f4eb5167ee4ab5ed1)",
  "embassy-time",
  "embassy-usb",
  "panic-reset",

--- a/experiments/soup-app-demo/Cargo.toml
+++ b/experiments/soup-app-demo/Cargo.toml
@@ -4,54 +4,39 @@ name = "soup-app-demo"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
-[features]
-default = ["nightly"]
-nightly = [
-    "embassy-executor/nightly",
-    "embassy-nrf/nightly",
-]
-
 [dependencies.embassy-futures]
 version = "0.1.0"
-# path = "../../embassy-futures"
 git = "https://github.com/embassy-rs/embassy"
-rev = "18fe398673f55b07159d01a230910bb9689c1525"
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 
 [dependencies.embassy-executor]
 version = "0.1.0"
-# path = "../../embassy-executor"
 git = "https://github.com/embassy-rs/embassy"
-rev = "18fe398673f55b07159d01a230910bb9689c1525"
-features = ["integrated-timers"]
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
+features = ["nightly", "integrated-timers"]
 
 [dependencies.embassy-nrf]
 version = "0.1.0"
-# path = "../../embassy-nrf"
 git = "https://github.com/embassy-rs/embassy"
-rev = "18fe398673f55b07159d01a230910bb9689c1525"
-features = ["nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"]
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
+features = ["nightly", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"]
 
 [dependencies.embassy-usb]
 version = "0.1.0"
-# path = "../../embassy-usb"
 git = "https://github.com/embassy-rs/embassy"
-rev = "18fe398673f55b07159d01a230910bb9689c1525"
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 features = ["msos-descriptor",]
-# optional = true
 
 [dependencies.embassy-time]
 version = "0.1.0"
 git = "https://github.com/embassy-rs/embassy"
-rev = "18fe398673f55b07159d01a230910bb9689c1525"
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 features = []
 
 [dependencies.embassy-sync]
 version = "0.1.0"
-# NOTE: using my version to include https://github.com/embassy-rs/embassy/pull/1296
-# git = "https://github.com/embassy-rs/embassy"
-# rev = "18fe398673f55b07159d01a230910bb9689c1525"
-git = "https://github.com/jamesmunns/embassy"
-rev = "4b5581be96f549cbab2f464f4eb5167ee4ab5ed1"
+git = "https://github.com/embassy-rs/embassy"
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 features = []
 
 [dependencies.soup-icd]
@@ -60,6 +45,7 @@ path = "../../shared/soup-icd"
 [dependencies]
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
+heapless = "0.7.16"
 panic-reset = "0.1.1"
 postcard = "1.0"
 

--- a/experiments/soup-app-demo/Cargo.toml
+++ b/experiments/soup-app-demo/Cargo.toml
@@ -87,8 +87,5 @@ codegen-units = 1
 debug = 2
 debug-assertions = false # <-
 incremental = false
-# NOTE disabled to work around issue rust-lang/rust#90357
-# the bug results in log messages not having location information
-# (the line printed below the log message that contains the file-line location)
 lto = 'fat'
 opt-level = 'z' # <-

--- a/experiments/soup-app-demo/Cargo.toml
+++ b/experiments/soup-app-demo/Cargo.toml
@@ -4,49 +4,23 @@ name = "soup-app-demo"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 
-[dependencies.embassy-futures]
-version = "0.1.0"
-git = "https://github.com/embassy-rs/embassy"
-rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
-
+# TODO: macros :(
 [dependencies.embassy-executor]
 version = "0.1.0"
 git = "https://github.com/embassy-rs/embassy"
 rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 features = ["nightly", "integrated-timers"]
 
-[dependencies.embassy-nrf]
-version = "0.1.0"
-git = "https://github.com/embassy-rs/embassy"
-rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
-features = ["nightly", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"]
-
-[dependencies.embassy-usb]
-version = "0.1.0"
-git = "https://github.com/embassy-rs/embassy"
-rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
-features = ["msos-descriptor",]
-
-[dependencies.embassy-time]
-version = "0.1.0"
-git = "https://github.com/embassy-rs/embassy"
-rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
-features = []
-
-[dependencies.embassy-sync]
-version = "0.1.0"
-git = "https://github.com/embassy-rs/embassy"
-rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
-features = []
-
 [dependencies.soup-icd]
 path = "../../shared/soup-icd"
+
+[dependencies.soup-stuff]
+path = "../../firmware/soup-stuff"
 
 [dependencies]
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
 heapless = "0.7.16"
-panic-reset = "0.1.1"
 postcard = "1.0"
 
 # cargo build/run

--- a/experiments/soup-app-demo/Cargo.toml
+++ b/experiments/soup-app-demo/Cargo.toml
@@ -47,8 +47,11 @@ features = []
 
 [dependencies.embassy-sync]
 version = "0.1.0"
-git = "https://github.com/embassy-rs/embassy"
-rev = "18fe398673f55b07159d01a230910bb9689c1525"
+# NOTE: using my version to include https://github.com/embassy-rs/embassy/pull/1296
+# git = "https://github.com/embassy-rs/embassy"
+# rev = "18fe398673f55b07159d01a230910bb9689c1525"
+git = "https://github.com/jamesmunns/embassy"
+rev = "4b5581be96f549cbab2f464f4eb5167ee4ab5ed1"
 features = []
 
 [dependencies.soup-icd]

--- a/experiments/soup-app-demo/run.sh
+++ b/experiments/soup-app-demo/run.sh
@@ -2,9 +2,12 @@
 
 set -euxo pipefail
 
+shopt -s expand_aliases
+alias soup-cli=../../host/soup-cli/target/release/soup-cli
+
 soup-cli stage0 poke -a 0x20000000 -f ./target/demo.bin
 soup-cli stage0 bootload -a 0x20000000
-soup-cli nop
+soup-cli stdio
 
 set +x
 

--- a/experiments/soup-app-demo/src/lib.rs
+++ b/experiments/soup-app-demo/src/lib.rs
@@ -1,0 +1,317 @@
+#![no_std]
+#![feature(type_alias_impl_trait)]
+
+use core::mem;
+
+use embassy_executor::Spawner;
+use embassy_nrf::{
+    bind_interrupts, pac,
+    peripherals::{self, USBD},
+    usb::{self, vbus_detect::HardwareVbusDetect, Driver},
+};
+use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
+use embassy_sync::{mutex::Mutex, pipe::Pipe};
+use embassy_usb::{
+    class::cdc_acm::{CdcAcmClass, Receiver, Sender, State},
+    driver::EndpointError,
+    Builder, Config, UsbDevice,
+};
+
+use panic_reset as _;
+use postcard::accumulator::{CobsAccumulator, FeedResult};
+use soup_icd::{Control, FromSoup, Managed, ToSoup};
+
+const ACC_SIZE: usize = 512;
+static STDOUT: Pipe<ThreadModeRawMutex, 256> = Pipe::new();
+static STDIN: Pipe<ThreadModeRawMutex, 256> = Pipe::new();
+static STDERR: Pipe<ThreadModeRawMutex, 256> = Pipe::new();
+
+bind_interrupts!(struct Irqs {
+    USBD => usb::InterruptHandler<peripherals::USBD>;
+    POWER_CLOCK => usb::vbus_detect::InterruptHandler;
+});
+
+fn welp<T>() -> &'static mut T {
+    cortex_m::peripheral::SCB::sys_reset();
+}
+
+macro_rules! singleton {
+    (: $ty:ty = $expr:expr) => {
+        cortex_m::singleton!(VAR: $ty = $expr).unwrap_or_else(welp)
+    };
+}
+
+type UsbSender = Sender<'static, Driver<'static, USBD, HardwareVbusDetect>>;
+type UsbReceiver = Receiver<'static, Driver<'static, USBD, HardwareVbusDetect>>;
+
+pub mod stdio {
+    use super::*;
+
+    pub struct Stdout;
+    pub struct Stderr;
+    pub struct Stdin;
+
+    static STDOUT_LOCK: Mutex<ThreadModeRawMutex, &'static Pipe<ThreadModeRawMutex, 256>> =
+        Mutex::new(&STDOUT);
+    static STDERR_LOCK: Mutex<ThreadModeRawMutex, &'static Pipe<ThreadModeRawMutex, 256>> =
+        Mutex::new(&STDERR);
+    static STDIN_LOCK: Mutex<ThreadModeRawMutex, &'static Pipe<ThreadModeRawMutex, 256>> =
+        Mutex::new(&STDIN);
+
+    impl Stdout {
+        pub async fn write_bytes_all(&self, mut s: &[u8]) {
+            let stdout = STDOUT_LOCK.lock().await;
+            while !s.is_empty() {
+                let n = stdout.write(s).await;
+                let (_now, later) = s.split_at(n);
+                s = later;
+            }
+        }
+    }
+
+    impl Stderr {
+        pub async fn write_bytes_all(&self, mut s: &[u8]) {
+            let stdout = STDERR_LOCK.lock().await;
+            while !s.is_empty() {
+                let n = stdout.write(s).await;
+                let (_now, later) = s.split_at(n);
+                s = later;
+            }
+        }
+    }
+
+    impl Stdin {
+        pub async fn read_some(&self, buf: &mut [u8]) -> usize {
+            let stdin = STDIN_LOCK.lock().await;
+
+            // Read once async
+            let taken = stdin.read(buf).await;
+            let (_now, later) = buf.split_at_mut(taken);
+
+            // Then once nonblocking (to catch wraparounds)
+            match stdin.try_read(later) {
+                Ok(n) => taken + n,
+                Err(_) => taken,
+            }
+        }
+
+        pub fn try_read_pending(&self, mut buf: &mut [u8]) -> usize {
+            let mut taken = 0;
+            let stdin = match STDIN_LOCK.try_lock() {
+                Ok(s) => s,
+                Err(_) => return 0,
+            };
+
+            while !buf.is_empty() {
+                match stdin.try_read(buf) {
+                    Ok(n) => {
+                        taken += n;
+                        let (_now, later) = buf.split_at_mut(n);
+                        buf = later;
+                    }
+                    Err(_) => return taken,
+                }
+            }
+
+            taken
+        }
+    }
+
+    pub fn stdout() -> Stdout {
+        Stdout
+    }
+
+    pub fn stderr() -> Stderr {
+        Stderr
+    }
+
+    pub fn stdin() -> Stdin {
+        Stdin
+    }
+}
+
+#[embassy_executor::task]
+async fn stdout(tx: &'static Mutex<ThreadModeRawMutex, UsbSender>) {
+    let mut scratch_in = [0u8; 32];
+    let mut scratch_out = [0u8; 64];
+
+    loop {
+        let n = STDOUT.read(&mut scratch_in).await;
+        if n != 0 {
+            let msg = FromSoup::Stdout(Managed::from_borrowed(&scratch_in[..n]));
+            if let Ok(sli) = postcard::to_slice_cobs(&msg, &mut scratch_out) {
+                let mut tx = tx.lock().await;
+                tx.wait_connection().await;
+                tx.write_packet(sli).await.ok();
+            }
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn stderr(tx: &'static Mutex<ThreadModeRawMutex, UsbSender>) {
+    let mut scratch_in = [0u8; 32];
+    let mut scratch_out = [0u8; 64];
+
+    loop {
+        let n = STDERR.read(&mut scratch_in).await;
+        if n != 0 {
+            let msg = FromSoup::Stderr(Managed::from_borrowed(&scratch_in[..n]));
+            if let Ok(sli) = postcard::to_slice_cobs(&msg, &mut scratch_out) {
+                let mut tx = tx.lock().await;
+                tx.wait_connection().await;
+                tx.write_packet(sli).await.ok();
+            }
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn usb_task(mut usb: UsbDevice<'static, Driver<'static, USBD, HardwareVbusDetect>>) {
+    usb.run().await;
+}
+
+#[embassy_executor::task]
+pub async fn soup_mgr(usb: USBD) {
+    let clock: pac::CLOCK = unsafe { mem::transmute(()) };
+    let spawner = Spawner::for_current_executor().await;
+
+    clock.tasks_hfclkstart.write(|w| unsafe { w.bits(1) });
+    while clock.events_hfclkstarted.read().bits() != 1 {}
+
+    // Create the driver, from the HAL.
+    let driver = Driver::new(usb, Irqs, HardwareVbusDetect::new(Irqs));
+
+    // Create embassy-usb Config
+    let mut config = Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("OneVariable");
+    config.product = Some("Soup App");
+    config.serial_number = Some("23456789");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    // Required for windows compatiblity.
+    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config.composite_with_iads = true;
+
+    // Create embassy-usb DeviceBuilder using the driver and config.
+    // It needs some buffers for building the descriptors.
+    //
+    // Use singletons to reduce stack usage.
+    let device_descriptor = singleton!(:[u8; 24] = [0; 24]);
+    let config_descriptor = singleton!(:[u8; 96] = [0; 96]);
+    let bos_descriptor = singleton!(:[u8; 16] = [0; 16]);
+    let msos_descriptor = singleton!(:[u8; 0] = [0; 0]);
+    let control_buf = singleton!(:[u8; 64] = [0; 64]);
+
+    let state = singleton!(:State = State::new());
+
+    let mut builder = Builder::new(
+        driver,
+        config,
+        device_descriptor,
+        config_descriptor,
+        bos_descriptor,
+        msos_descriptor,
+        control_buf,
+    );
+
+    // Create classes on the builder.
+    let class = CdcAcmClass::new(&mut builder, state, 64);
+
+    // Build the builder.
+    let usb = builder.build();
+
+    let (tx, mut rx) = class.split();
+
+    let tx = &*singleton!(: Mutex<ThreadModeRawMutex, UsbSender> = Mutex::new(tx));
+
+    spawner.spawn(stdout(tx)).ok();
+    spawner.spawn(stderr(tx)).ok();
+    spawner.spawn(usb_task(usb)).ok();
+
+    // Do stuff with the class!
+    let soup_comms = async {
+        loop {
+            rx.wait_connection().await;
+            let _ = minimal(&mut rx, tx).await;
+        }
+    };
+
+    // Run everything concurrently.
+    // If we had made everything `'static` above instead, we could do this using separate tasks instead.
+    soup_comms.await;
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn minimal(
+    rx: &mut UsbReceiver,
+    tx: &Mutex<ThreadModeRawMutex, UsbSender>,
+) -> Result<(), Disconnected> {
+    let mut buf = [0; 64];
+    let mut outbuf = [0u8; 512];
+
+    let mut acc = CobsAccumulator::<ACC_SIZE>::new();
+    loop {
+        let n = rx.read_packet(&mut buf).await?;
+        let mut window = &buf[..n];
+
+        'cobs: while !window.is_empty() {
+            use FeedResult::*;
+
+            window = match acc.feed_ref::<ToSoup<'_>>(&window) {
+                Consumed => break 'cobs,
+                OverFull(new_wind) | DeserError(new_wind) => new_wind,
+                Success { data, remaining } => {
+                    let resp = req_handler(data, &mut outbuf).await;
+
+                    if !resp.is_empty() {
+                        let mut tx = tx.lock().await;
+                        for ch in resp.chunks(64) {
+                            tx.wait_connection().await;
+                            tx.write_packet(ch).await?;
+                        }
+                    }
+
+                    remaining
+                }
+            };
+        }
+    }
+}
+
+async fn req_handler<'a>(req: ToSoup<'_>, outbuf: &'a mut [u8]) -> &'a [u8] {
+    let resp: Option<FromSoup<'_>> = match req {
+        ToSoup::Control(Control::Reboot) => {
+            cortex_m::peripheral::SCB::sys_reset();
+        }
+        ToSoup::Control(Control::SendAppInfo) => None,
+        ToSoup::Stdin(si) => {
+            STDIN.write(si.as_slice()).await;
+            None
+        }
+        ToSoup::ToApp(_) => todo!(),
+    };
+
+    if let Some(res) = resp {
+        match postcard::to_slice_cobs(&res, outbuf) {
+            Ok(ser) => ser,
+            Err(_) => &[0x00],
+        }
+    } else {
+        &[]
+    }
+}

--- a/experiments/soup-app-demo/src/main.rs
+++ b/experiments/soup-app-demo/src/main.rs
@@ -2,10 +2,15 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use embassy_executor::Spawner;
-use embassy_nrf::gpio::{AnyPin, Level, Output, OutputDrive, Pin};
-use embassy_time::{Duration, Timer};
-use soup_app_demo::{
+use soup_stuff::{
+    embassy::{
+        embassy_executor::Spawner,
+        embassy_nrf::{
+            self,
+            gpio::{AnyPin, Level, Output, OutputDrive, Pin},
+        },
+        embassy_time::{Duration, Timer},
+    },
     soup_mgr,
     stdio::{stderr, stdin, stdout},
 };
@@ -37,7 +42,7 @@ async fn run1() {
 
 #[embassy_executor::task]
 async fn run2() {
-    Timer::after(Duration::from_ticks(32768)).await;
+    Timer::after(Duration::from_ticks(40000)).await;
     loop {
         Timer::after(Duration::from_ticks(12 * 32768)).await;
         stderr().write_bytes_all(b"hello, error!\r\n").await;

--- a/experiments/soup-app-demo/src/main.rs
+++ b/experiments/soup-app-demo/src/main.rs
@@ -2,68 +2,45 @@
 #![no_main]
 #![feature(type_alias_impl_trait)]
 
-use core::mem;
-
 use embassy_executor::Spawner;
-use embassy_futures::join::join;
-use embassy_nrf::{
-    bind_interrupts,
-    gpio::{Level, Output, OutputDrive, Pin, AnyPin},
-    pac,
-    peripherals::{self, USBD},
-    usb::{
-        self,
-        vbus_detect::HardwareVbusDetect,
-        Driver,
-    },
-};
-use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
-use embassy_usb::{
-    class::cdc_acm::{CdcAcmClass, Receiver, Sender, State},
-    driver::EndpointError,
-    Builder, Config,
-};
-use embassy_sync::{mutex::Mutex, pipe::Pipe};
+use embassy_nrf::gpio::{AnyPin, Level, Output, OutputDrive, Pin};
 use embassy_time::{Duration, Timer};
+use soup_app_demo::{
+    soup_mgr,
+    stdio::{stderr, stdin, stdout},
+};
 
-use panic_reset as _;
-use postcard::accumulator::{CobsAccumulator, FeedResult};
-use soup_icd::{Control, FromSoup, Managed, ToSoup};
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
 
-bind_interrupts!(struct Irqs {
-    USBD => usb::InterruptHandler<peripherals::USBD>;
-    POWER_CLOCK => usb::vbus_detect::InterruptHandler;
-});
+    let leds = [
+        Output::new(p.P0_06.degrade(), Level::High, OutputDrive::Standard),
+        Output::new(p.P0_26.degrade(), Level::High, OutputDrive::Standard),
+        Output::new(p.P0_30.degrade(), Level::High, OutputDrive::Standard),
+    ];
 
-const ACC_SIZE: usize = 512;
-static STDOUT: Pipe<ThreadModeRawMutex, 256> = Pipe::new();
-static STDIN: Pipe<ThreadModeRawMutex, 256> = Pipe::new();
-static STDERR: Pipe<ThreadModeRawMutex, 256> = Pipe::new();
-
-fn welp<T>() -> &'static mut T {
-    cortex_m::peripheral::SCB::sys_reset();
-}
-
-macro_rules! singleton {
-    (: $ty:ty = $expr:expr) => {
-        cortex_m::singleton!(VAR: $ty = $expr).unwrap_or_else(welp)
-    };
+    spawner.spawn(soup_mgr(p.USBD)).ok();
+    spawner.spawn(run1()).ok();
+    spawner.spawn(run2()).ok();
+    spawner.spawn(run3(leds)).ok();
 }
 
 #[embassy_executor::task]
 async fn run1() {
+    Timer::after(Duration::from_ticks(32768)).await;
     loop {
-        Timer::after(Duration::from_ticks(32768 * 5)).await;
-        STDOUT.write(b"hello, world!\r\n").await;
+        stdout().write_bytes_all(b"hello, world!\r\n").await;
+        Timer::after(Duration::from_ticks(32768)).await;
     }
 }
 
 #[embassy_executor::task]
 async fn run2() {
-    Timer::after(Duration::from_ticks(32768 / 4)).await;
+    Timer::after(Duration::from_ticks(32768)).await;
     loop {
         Timer::after(Duration::from_ticks(12 * 32768)).await;
-        STDERR.write(b"hello, error!\r\n").await;
+        stderr().write_bytes_all(b"hello, error!\r\n").await;
     }
 }
 
@@ -83,220 +60,16 @@ async fn run3(mut leds: [Output<'static, AnyPin>; 3]) {
         });
         idx = idx.wrapping_add(1);
     }
-
 }
 
 #[embassy_executor::task]
 async fn echo() {
     let mut buf = [0u8; 32];
     loop {
-        let n = STDIN.read(&mut buf).await;
+        let n = stdin().read_some(&mut buf).await;
         if n != 0 {
-            STDOUT.write(b"Echo: ").await;
-            STDOUT.write(&buf[..n]).await;
+            stdout().write_bytes_all(b"Echo: ").await;
+            stdout().write_bytes_all(&buf[..n]).await;
         }
     }
 }
-
-type UsbSender = Sender<'static, Driver<'static, USBD, HardwareVbusDetect>>;
-type UsbReceiver = Receiver<'static, Driver<'static, USBD, HardwareVbusDetect>>;
-
-#[embassy_executor::task]
-async fn stdout(tx: &'static Mutex<ThreadModeRawMutex, UsbSender>) {
-    let mut scratch_in = [0u8; 32];
-    let mut scratch_out = [0u8; 64];
-
-    loop {
-        let n = STDOUT.read(&mut scratch_in).await;
-        if n != 0 {
-            let msg = FromSoup::Stdout(Managed::from_borrowed(&scratch_in[..n]));
-            if let Ok(sli) = postcard::to_slice_cobs(&msg, &mut scratch_out) {
-                let mut tx = tx.lock().await;
-                tx.wait_connection().await;
-                tx.write_packet(sli).await.ok();
-            }
-        }
-    }
-}
-
-#[embassy_executor::task]
-async fn stderr(tx: &'static Mutex<ThreadModeRawMutex, UsbSender>) {
-    let mut scratch_in = [0u8; 32];
-    let mut scratch_out = [0u8; 64];
-
-    loop {
-        let n = STDERR.read(&mut scratch_in).await;
-        if n != 0 {
-            let msg = FromSoup::Stderr(Managed::from_borrowed(&scratch_in[..n]));
-            if let Ok(sli) = postcard::to_slice_cobs(&msg, &mut scratch_out) {
-                let mut tx = tx.lock().await;
-                tx.wait_connection().await;
-                tx.write_packet(sli).await.ok();
-            }
-        }
-    }
-}
-
-#[embassy_executor::main]
-async fn main(spawner: Spawner) {
-    let p = embassy_nrf::init(Default::default());
-
-    let clock: pac::CLOCK = unsafe { mem::transmute(()) };
-    let leds = [
-        Output::new(p.P0_06.degrade(), Level::High, OutputDrive::Standard),
-        Output::new(p.P0_26.degrade(), Level::High, OutputDrive::Standard),
-        Output::new(p.P0_30.degrade(), Level::High, OutputDrive::Standard),
-    ];
-
-    // info!("Enabling ext hfosc...");
-    clock.tasks_hfclkstart.write(|w| unsafe { w.bits(1) });
-    while clock.events_hfclkstarted.read().bits() != 1 {}
-
-    // Create the driver, from the HAL.
-    let driver = Driver::new(p.USBD, Irqs, HardwareVbusDetect::new(Irqs));
-
-    // Create embassy-usb Config
-    let mut config = Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("OneVariable");
-    config.product = Some("Soup App");
-    config.serial_number = Some("23456789");
-    config.max_power = 100;
-    config.max_packet_size_0 = 64;
-
-    // Required for windows compatiblity.
-    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
-    config.device_class = 0xEF;
-    config.device_sub_class = 0x02;
-    config.device_protocol = 0x01;
-    config.composite_with_iads = true;
-
-    // Create embassy-usb DeviceBuilder using the driver and config.
-    // It needs some buffers for building the descriptors.
-    //
-    // Use singletons to reduce stack usage.
-    let device_descriptor = singleton!(:[u8; 256] = [0; 256]);
-    let config_descriptor = singleton!(:[u8; 256] = [0; 256]);
-    let bos_descriptor = singleton!(:[u8; 256] = [0; 256]);
-    let msos_descriptor = singleton!(:[u8; 256] = [0; 256]);
-    let control_buf = singleton!(:[u8; 64] = [0; 64]);
-
-    let state = singleton!(:State = State::new());
-
-    let mut builder = Builder::new(
-        driver,
-        config,
-        device_descriptor,
-        config_descriptor,
-        bos_descriptor,
-        msos_descriptor,
-        control_buf,
-    );
-
-    // Create classes on the builder.
-    let class = CdcAcmClass::new(&mut builder, state, 64);
-
-    // Build the builder.
-    let mut usb = builder.build();
-
-    // Run the USB device.
-    let usb_fut = usb.run();
-
-    let (tx, mut rx) = class.split();
-
-    let tx = &*singleton!(: Mutex<ThreadModeRawMutex, UsbSender> = Mutex::new(tx));
-
-    spawner.spawn(stdout(tx)).ok();
-    spawner.spawn(stderr(tx)).ok();
-    spawner.spawn(run1()).ok();
-    spawner.spawn(run2()).ok();
-    spawner.spawn(run3(leds)).ok();
-    spawner.spawn(echo()).ok();
-
-    // Do stuff with the class!
-    let soup_comms = async {
-        loop {
-            rx.wait_connection().await;
-            let _ = minimal(&mut rx, tx).await;
-        }
-    };
-
-    // Run everything concurrently.
-    // If we had made everything `'static` above instead, we could do this using separate tasks instead.
-    join(usb_fut, soup_comms).await;
-}
-
-struct Disconnected {}
-
-impl From<EndpointError> for Disconnected {
-    fn from(val: EndpointError) -> Self {
-        match val {
-            EndpointError::BufferOverflow => panic!("Buffer overflow"),
-            EndpointError::Disabled => Disconnected {},
-        }
-    }
-}
-
-async fn minimal(
-    rx: &mut UsbReceiver,
-    tx: &Mutex<ThreadModeRawMutex, UsbSender>,
-) -> Result<(), Disconnected> {
-    let mut buf = [0; 64];
-    let mut outbuf = [0u8; 512];
-
-    let mut acc = CobsAccumulator::<ACC_SIZE>::new();
-    loop {
-        let n = rx.read_packet(&mut buf).await?;
-        let mut window = &buf[..n];
-
-        'cobs: while !window.is_empty() {
-            use FeedResult::*;
-
-            window = match acc.feed_ref::<ToSoup<'_>>(&window) {
-                Consumed => break 'cobs,
-                OverFull(new_wind) | DeserError(new_wind) => new_wind,
-                Success { data, remaining } => {
-                    let resp = req_handler(data, &mut outbuf).await;
-
-                    if !resp.is_empty() {
-                        let mut tx = tx.lock().await;
-                        for ch in resp.chunks(64) {
-                            tx.wait_connection().await;
-                            tx.write_packet(ch).await?;
-                        }
-                    }
-
-                    remaining
-                }
-            };
-        }
-    }
-}
-
-async fn req_handler<'a>(req: ToSoup<'_>, outbuf: &'a mut [u8]) -> &'a [u8] {
-    let resp: Option<FromSoup<'_>> = match req {
-        ToSoup::Control(Control::Reboot) => {
-            cortex_m::peripheral::SCB::sys_reset();
-        }
-        ToSoup::Control(Control::SendAppInfo) => {
-            None
-        }
-        ToSoup::Stdin(si) => {
-            STDIN.write(si.as_slice()).await;
-            None
-        },
-        ToSoup::ToApp(_) => todo!(),
-    };
-
-    if let Some(res) = resp {
-        match postcard::to_slice_cobs(&res, outbuf) {
-            Ok(ser) => ser,
-            Err(_) => {
-                &[0x00]
-            },
-        }
-    } else {
-        &[]
-    }
-
-}
-

--- a/experiments/soup-app-demo/src/main.rs
+++ b/experiments/soup-app-demo/src/main.rs
@@ -51,7 +51,7 @@ macro_rules! singleton {
 #[embassy_executor::task]
 async fn run1() {
     loop {
-        Timer::after(Duration::from_ticks(64000)).await;
+        Timer::after(Duration::from_ticks(32768)).await;
         STDOUT.write(b"hello, world!\r\n").await;
     }
 }

--- a/firmware/soup-stuff/.cargo/config.toml
+++ b/firmware/soup-stuff/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/firmware/soup-stuff/Cargo.lock
+++ b/firmware/soup-stuff/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
+checksum = "c314e70d181aa6053b26e3f7fbf86d1dfff84f816a6175b967666b3506ef7289"
 dependencies = [
  "critical-section",
 ]
@@ -101,7 +101,7 @@ checksum = "f0f6f3e36f203cfedbc78b357fb28730aa2c6dc1ab060ee5c2405e843988d3c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -137,7 +137,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ name = "embassy-cortex-m"
 version = "0.1.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
- "atomic-polyfill 1.0.1",
+ "atomic-polyfill 1.0.2",
  "cfg-if",
  "cortex-m",
  "critical-section",
@@ -177,7 +177,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-storage",
  "embedded-storage-async",
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ name = "embassy-executor"
 version = "0.1.1"
 source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
- "atomic-polyfill 1.0.1",
+ "atomic-polyfill 1.0.2",
  "cfg-if",
  "critical-section",
  "embassy-macros",
@@ -215,7 +215,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -277,7 +277,7 @@ name = "embassy-time"
 version = "0.1.0"
 source = "git+https://github.com/embassy-rs/embassy?rev=7a841b58d127cc6d22c8895197d3f4d4c0974ad7#7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
 dependencies = [
- "atomic-polyfill 1.0.1",
+ "atomic-polyfill 1.0.2",
  "cfg-if",
  "critical-section",
  "embassy-sync",
@@ -359,9 +359,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "fixed"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f3be4cf4fc227d3a63bb77512a2b7d364200b2a715f389155785c4d3345495"
+checksum = "79386fdcec5e0fde91b1a6a5bcd89677d1f9304f7f986b154a1b9109038854d9"
 dependencies = [
  "az",
  "bytemuck",
@@ -377,9 +377,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -401,33 +401,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -490,14 +490,14 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
 dependencies = [
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
 name = "nb"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "nrf52840-pac"
@@ -553,18 +553,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -590,7 +590,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.17",
 ]
 
 [[package]]
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "semver-parser"
@@ -622,35 +622,22 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.155"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.155"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "soup-app-demo"
-version = "0.1.0"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "embassy-executor",
- "heapless",
- "postcard",
- "soup-icd",
- "soup-stuff",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -685,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
 dependencies = [
  "lock_api",
 ]
@@ -714,7 +701,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c37c250d21f53fa7165e76e5401d7e6539c211a8d2cf449e3962956a5cc2ce"
 dependencies = [
- "atomic-polyfill 1.0.1",
+ "atomic-polyfill 1.0.2",
 ]
 
 [[package]]
@@ -728,6 +715,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -783,7 +781,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 1.0.109",
  "usbd-hid-descriptors",
 ]
 

--- a/firmware/soup-stuff/Cargo.toml
+++ b/firmware/soup-stuff/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "soup-stuff"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies.embassy-executor]
+version = "0.1.0"
+git = "https://github.com/embassy-rs/embassy"
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
+features = ["nightly", "integrated-timers"]
+
+[dependencies.embassy-nrf]
+version = "0.1.0"
+git = "https://github.com/embassy-rs/embassy"
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
+features = ["nightly", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"]
+
+[dependencies.embassy-usb]
+version = "0.1.0"
+git = "https://github.com/embassy-rs/embassy"
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
+features = ["msos-descriptor",]
+
+[dependencies.embassy-time]
+version = "0.1.0"
+git = "https://github.com/embassy-rs/embassy"
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
+features = []
+
+[dependencies.embassy-sync]
+version = "0.1.0"
+git = "https://github.com/embassy-rs/embassy"
+rev = "7a841b58d127cc6d22c8895197d3f4d4c0974ad7"
+features = []
+
+[dependencies.soup-icd]
+path = "../../shared/soup-icd"
+
+[dependencies]
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
+panic-reset = "0.1.1"
+postcard = "1.0"

--- a/firmware/soup-stuff/rust-toolchain.toml
+++ b/firmware/soup-stuff/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Before upgrading check that everything is available on all tier1 targets here:
+# https://rust-lang.github.io/rustup-components-history
+[toolchain]
+channel = "nightly-2023-02-07"
+components = [ "rust-src", "rustfmt", "llvm-tools-preview" ]
+targets = [
+    "thumbv7em-none-eabi",
+    "thumbv7em-none-eabihf",
+]

--- a/firmware/soup-stuff/src/lib.rs
+++ b/firmware/soup-stuff/src/lib.rs
@@ -9,8 +9,7 @@ use embassy_nrf::{
     peripherals::{self, USBD},
     usb::{self, vbus_detect::HardwareVbusDetect, Driver},
 };
-use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
-use embassy_sync::{mutex::Mutex, pipe::Pipe};
+use embassy_sync::{blocking_mutex::raw::ThreadModeRawMutex, mutex::Mutex, pipe::Pipe};
 use embassy_usb::{
     class::cdc_acm::{CdcAcmClass, Receiver, Sender, State},
     driver::EndpointError,
@@ -20,6 +19,14 @@ use embassy_usb::{
 use panic_reset as _;
 use postcard::accumulator::{CobsAccumulator, FeedResult};
 use soup_icd::{Control, FromSoup, Managed, ToSoup};
+
+pub mod embassy {
+    pub use embassy_executor;
+    pub use embassy_nrf;
+    pub use embassy_usb;
+    pub use embassy_time;
+    pub use embassy_sync;
+}
 
 const ACC_SIZE: usize = 512;
 static STDOUT: Pipe<ThreadModeRawMutex, 256> = Pipe::new();

--- a/host/soup-cli/src/cli.rs
+++ b/host/soup-cli/src/cli.rs
@@ -15,6 +15,8 @@ pub enum Soup {
     Nop,
     /// Stage0 Loader Commands
     Stage0(S0Shim),
+    /// Connect stdio (and err) to the console
+    Stdio,
 }
 
 #[derive(Args, Debug)]

--- a/host/soup-cli/src/main.rs
+++ b/host/soup-cli/src/main.rs
@@ -4,8 +4,8 @@ use postcard::{
     to_stdvec_cobs,
 };
 use serialport::SerialPort;
-use soup_icd::{Managed, ToSoup};
-use stage0_icd::{Error as IcdError, PeekBytes, Poked, Request, Response};
+use soup_icd::{Managed, ToSoup, FromSoup};
+use stage0_icd::{Error as IcdError, PeekBytes, Poked, Request, Response as S0Response};
 use std::{
     cmp::min,
     error::Error,
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut last_err: Option<FindError> = None;
 
     let looking_for = match cmd {
-        Soup::Reboot | Soup::Nop => PortKind::SoupApp,
+        Soup::Reboot | Soup::Nop | Soup::Stdio => PortKind::SoupApp,
         Soup::Stage0(_) => PortKind::Stage0,
     };
 
@@ -100,6 +100,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 Ok(())
             }
         },
+        Soup::Stdio => stdio(port.deref_mut()),
     }?;
 
     Ok(())
@@ -187,16 +188,73 @@ fn get_port() -> Result<(PortKind, Box<dyn SerialPort>), FindError> {
     Ok((*kind, port))
 }
 
+fn stdio(port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>> {
+    println!("====================");
+    println!("Forwarding Stdio... ");
+    println!("====================");
+
+
+    let mut acc = CobsAccumulator::<512>::new();
+
+    let mut raw_buf = [0u8; 32];
+
+    let mut stdout = std::io::stdout();
+    let mut stderr = std::io::stderr();
+
+    'outer: loop {
+        let mut buf = match port.read(&mut raw_buf) {
+            Ok(0) => todo!(),
+            Ok(n) => &raw_buf[..n],
+            Err(e) if e.kind() == ErrorKind::TimedOut => {
+                continue 'outer;
+            }
+            Err(e) => {
+                panic!("{e:?}");
+            }
+        };
+
+        'cobs: while !buf.is_empty() {
+            buf = match acc.feed_ref::<FromSoup<'_>>(buf) {
+                FeedResult::Consumed => break 'cobs,
+                FeedResult::OverFull(new_wind) => {
+                    println!("OVERFULL ERR");
+                    new_wind
+                },
+                FeedResult::DeserError(new_wind) => {
+                    println!("DESER ERR");
+                    new_wind
+                },
+                FeedResult::Success { data, remaining } => {
+                    match data {
+                        FromSoup::Stdout(r) => {
+                            print!("{}", String::from_utf8_lossy(r.as_slice()));
+                            stdout.flush()?;
+                        },
+                        FromSoup::Stderr(r) => {
+                            eprint!("{}", String::from_utf8_lossy(r.as_slice()));
+                            stderr.flush()?;
+                        },
+                        FromSoup::ControlResponse(r) => todo!(),
+                        FromSoup::FromApp(r) => todo!(),
+                        FromSoup::Error(r) => todo!(),
+                    }
+                    remaining
+                }
+            };
+        }
+    }
+}
+
 fn send<T: serde::Serialize>(cmd: T, port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>> {
     let sercmd = to_stdvec_cobs(&cmd)?;
-    port.write(&[0x00])?;
-    port.write(&sercmd)?;
+    port.write_all(&[0x00])?;
+    port.write_all(&sercmd)?;
     Ok(())
 }
 
 fn recv_s0<F, T>(matcher: F, port: &mut dyn SerialPort) -> Result<T, Box<dyn Error>>
 where
-    F: Fn(&Response<'_>) -> Option<T>,
+    F: Fn(&S0Response<'_>) -> Option<T>,
 {
     let mut acc = CobsAccumulator::<512>::new();
 
@@ -215,7 +273,7 @@ where
         };
 
         'cobs: while !buf.is_empty() {
-            buf = match acc.feed_ref::<Result<Response<'_>, IcdError>>(&buf) {
+            buf = match acc.feed_ref::<Result<S0Response<'_>, IcdError>>(buf) {
                 FeedResult::Consumed => break 'cobs,
                 FeedResult::OverFull(new_wind) => new_wind,
                 FeedResult::DeserError(new_wind) => new_wind,
@@ -256,7 +314,7 @@ fn peek(cmd: Peek, port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>> {
         )?;
         let resp = recv_s0::<_, PeekBytes<'static>>(
             |r| match r {
-                Response::PeekBytes(t) if t.addr == idx => Some(t.to_owned()),
+                S0Response::PeekBytes(t) if t.addr == idx => Some(t.to_owned()),
                 _ => None,
             },
             port,
@@ -266,7 +324,7 @@ fn peek(cmd: Peek, port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>> {
     }
 
     if let Some(f) = cmd.file {
-        let mut file = File::create(&f)?;
+        let mut file = File::create(f)?;
         file.write_all(&data)?;
     } else {
         data.chunks(16).for_each(|ch| {
@@ -314,7 +372,7 @@ fn poke(cmd: Poke, port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>> {
         )?;
         let _ = recv_s0::<_, Poked>(
             |r| match r {
-                Response::Poked(t) if t.addr == idx => Some(Poked { addr: t.addr }),
+                S0Response::Poked(t) if t.addr == idx => Some(Poked { addr: t.addr }),
                 _ => None,
             },
             port,

--- a/host/soup-cli/src/main.rs
+++ b/host/soup-cli/src/main.rs
@@ -250,9 +250,9 @@ fn stdio(port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>> {
                             eprint!("{}", String::from_utf8_lossy(r.as_slice()));
                             stderr.flush()?;
                         },
-                        FromSoup::ControlResponse(r) => todo!(),
-                        FromSoup::FromApp(r) => todo!(),
-                        FromSoup::Error(r) => todo!(),
+                        FromSoup::ControlResponse(_r) => todo!(),
+                        FromSoup::FromApp(_r) => todo!(),
+                        FromSoup::Error(_r) => todo!(),
                     }
                     remaining
                 }


### PR DESCRIPTION
WIP.

Currently includes https://github.com/embassy-rs/embassy/pull/1296.

Prior to that PR, I was seeing "glitches" on wraparound:

```
[03:51:33.906488] ====================
[03:51:33.906502] Forwarding Stdio...
[03:51:33.906513] ====================
[03:51:34.373182] hello, world!
[03:51:35.373059] hello, world!
[03:51:36.372532] hello, world!
...
[03:51:50.372059] hello, world!
[03:51:52.372260] hhello, world! <-- here
[03:51:53.372255] hello, world!
...
[03:52:08.371360] hello, world!
[03:52:10.371213] hhello, world! <-- here
[03:52:11.371210] hello, world!
```

The times marked at <--here show a delay of TWO seconds, instead of one, and the additional `h` was the message that came in at the wraparound point.