### PR TITLE
Add `soup-cli run` command

### DIFF
--- a/experiments/soup-app-demo/.cargo/config.toml
+++ b/experiments/soup-app-demo/.cargo/config.toml
@@ -1,6 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# replace nRF82840_xxAA with your chip as listed in `probe-run --list-chips`
-runner = "probe-run --chip nRF52840_xxAA"
+runner = "soup-cli run"
 
 [build]
 target = "thumbv7em-none-eabi"

--- a/host/soup-cli/Cargo.lock
+++ b/host/soup-cli/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,10 +131,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "hash32"
@@ -245,6 +276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "nix"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,9 +292,19 @@ checksum = "dd0eaf8df8bab402257e0a5c17a254e4cc1f72a93588a1ddfb5d356c801aa7cb"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "flate2",
+ "memchr",
 ]
 
 [[package]]
@@ -392,7 +442,7 @@ dependencies = [
  "CoreFoundation-sys",
  "IOKit-sys",
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libudev",
  "mach 0.2.3",
  "nix",
@@ -405,6 +455,7 @@ name = "soup-cli"
 version = "2.0.0"
 dependencies = [
  "clap",
+ "object",
  "postcard",
  "serde",
  "serialport",

--- a/host/soup-cli/Cargo.toml
+++ b/host/soup-cli/Cargo.toml
@@ -19,6 +19,7 @@ serialport = "4.0.1"
 clap = { version = "3.0.14", features = ["derive"] }
 postcard = { version = "1.0", features = ["use-std"] }
 serde = "1.0"
+object = { version = "0.30", features = ["read", "std"] }
 
 [dependencies.soup-icd]
 path = "../../shared/soup-icd"

--- a/host/soup-cli/src/cli.rs
+++ b/host/soup-cli/src/cli.rs
@@ -17,6 +17,13 @@ pub enum Soup {
     Stage0(S0Shim),
     /// Connect stdio (and err) to the console
     Stdio,
+    /// Run
+    Run(Run)
+}
+
+#[derive(Args, Debug)]
+pub struct Run {
+    pub elf_path: String,
 }
 
 #[derive(Args, Debug)]

--- a/host/soup-cli/src/elf.rs
+++ b/host/soup-cli/src/elf.rs
@@ -1,0 +1,152 @@
+use object::{
+    elf::{FileHeader32, PT_LOAD},
+    read::elf::{FileHeader, ProgramHeader},
+    LittleEndian, Object, ObjectSection,
+};
+use std::{
+    cmp::Ordering,
+    error::Error,
+    fs,
+    ops::Range,
+};
+
+pub struct Loadable {
+    pub addr: u32,
+    pub data: Vec<u8>,
+}
+
+pub fn parse_loadable(s: String) -> Result<Loadable, Box<dyn Error>> {
+    let bin_data = fs::read(&s)?;
+    let obj_file = object::File::parse(&*bin_data)?;
+
+    match obj_file.format() {
+        object::BinaryFormat::Elf => {}
+        _ => return Err("Unsupported format. Only elf.".into()),
+    }
+
+    if !obj_file.is_little_endian() {
+        return Err("Only LE supported".into());
+    }
+
+    let file_kind = object::FileKind::parse(&*bin_data)?;
+
+    match file_kind {
+        object::FileKind::Elf32 => {}
+        fk => return Err(format!("Unsupported file type: {:?}", fk).into()),
+    }
+
+    let elf_header = FileHeader32::<LittleEndian>::parse(&*bin_data)?;
+    let endian = elf_header.endian()?;
+
+    let mut lowest_addr = u64::MAX;
+    let mut highest_addr = u64::MIN;
+    let mut bin_contents = vec![];
+
+    // NOTE: Using https://github.com/probe-rs/probe-rs/blob/5a29e83847118c3999a2ca0ab017f080719b8ae5/probe-rs/src/flashing/download.rs#L194
+    // as a reference
+    for segment in elf_header.program_headers(endian, &*bin_data)? {
+        let p_paddr: u64 = segment.p_paddr(endian).into();
+        let _p_vaddr: u64 = segment.p_vaddr(endian).into();
+        let _flags = segment.p_flags(endian);
+
+        let segment_data = segment.data(endian, &*bin_data).map_err(|_| {
+            "Failed to get segment data"
+        })?;
+
+        let load = segment.p_type(endian) == PT_LOAD;
+        let _sz = segment_data.len();
+
+        // println!("{p_paddr:08X}, {p_vaddr:08X}, {flags:08X}, sz: {sz}, l?: {load}");
+
+        if !load {
+            continue;
+        }
+
+        let (segment_offset, segment_filesize) = segment.file_range(endian);
+
+        let sector: core::ops::Range<u64> = segment_offset..segment_offset + segment_filesize;
+
+        for section in obj_file.sections() {
+            let (section_offset, section_filesize) = match section.file_range() {
+                Some(range) => range,
+                None => continue,
+            };
+
+            if sector.contains_range(&(section_offset..section_offset + section_filesize)) {
+                // println!("  -> Matching section: {:?}", section.name()?);
+                // println!("  -> {:08X}, {}", p_paddr, segment_data.len());
+
+                lowest_addr = lowest_addr.min(p_paddr);
+                let fsz: u32 = segment.p_filesz(endian);
+                let fsz64: u64 = fsz.into();
+                assert_eq!(segment_data.len(), fsz.try_into()?);
+
+                highest_addr = highest_addr.max(p_paddr + fsz64);
+                bin_contents.push((p_paddr, segment_data));
+
+                for (offset, relocation) in section.relocations() {
+                    return Err(format!(
+                        "I can't do relocations sorry: ({}) {:?}, {:?}",
+                        section.name()?,
+                        offset,
+                        relocation,
+                    ).into());
+                }
+            }
+        }
+    }
+
+    match lowest_addr.cmp(&highest_addr) {
+        Ordering::Less => {}
+        Ordering::Equal => return Err("Empty file?".into()),
+        Ordering::Greater if bin_contents.is_empty() => return Err("No sections found?".into()),
+        Ordering::Greater => return Err("Start is after end?".into()),
+    }
+
+    let ttl_len: usize = (highest_addr - lowest_addr).try_into()?;
+    // println!("start: 0x{lowest_addr:08X}");
+    // println!("end:   0x{highest_addr:08X}");
+    // println!("size:  {ttl_len}");
+
+    let mut output = vec![0x00u8; ttl_len];
+    for (addr, data) in bin_contents.iter() {
+        let adj_addr = (addr - lowest_addr).try_into()?;
+        let size = data.len();
+        output[adj_addr..][..size].copy_from_slice(data);
+    }
+
+    Ok(Loadable { addr: lowest_addr.try_into()?, data: output })
+}
+
+///////
+// https://github.com/probe-rs/probe-rs/blob/ef635f213a2741ebac4c1ccfb700230992dd10a6/probe-rs-target/src/memory.rs#L102-L130
+///////
+
+pub trait MemoryRange {
+    /// Returns true if `self` contains `range` fully.
+    fn contains_range(&self, range: &Range<u64>) -> bool;
+
+    /// Returns true if `self` intersects `range` partially.
+    fn intersects_range(&self, range: &Range<u64>) -> bool;
+}
+
+impl MemoryRange for Range<u64> {
+    fn contains_range(&self, range: &Range<u64>) -> bool {
+        if range.end == 0 {
+            false
+        } else {
+            self.contains(&range.start) && self.contains(&(range.end - 1))
+        }
+    }
+
+    fn intersects_range(&self, range: &Range<u64>) -> bool {
+        if range.end == 0 {
+            false
+        } else {
+            self.contains(&range.start) && !self.contains(&(range.end - 1))
+                || !self.contains(&range.start) && self.contains(&(range.end - 1))
+                || self.contains_range(range)
+                || range.contains_range(self)
+        }
+    }
+}

--- a/host/soup-cli/src/main.rs
+++ b/host/soup-cli/src/main.rs
@@ -4,106 +4,92 @@ use postcard::{
     to_stdvec_cobs,
 };
 use serialport::SerialPort;
-use soup_icd::{Managed, ToSoup, FromSoup};
+use soup_icd::{FromSoup, Managed, ToSoup};
 use stage0_icd::{Error as IcdError, PeekBytes, Poked, Request, Response as S0Response};
 use std::{
     cmp::min,
     error::Error,
-    fmt::Display,
     fs::File,
     io::{ErrorKind, Read, Write},
     ops::DerefMut,
-    time::Duration, sync::mpsc::channel,
+    sync::mpsc::channel,
 };
 
 mod cli;
-use cli::{Peek, Poke, Soup, Stage0};
+mod elf;
+mod port;
+
+use crate::{
+    cli::{Peek, Poke, Run, Soup, Stage0, WriteBytes},
+    elf::parse_loadable,
+    port::{connect, PortKind},
+};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let cmd = Soup::parse();
-    let mut last_err: Option<FindError> = None;
-
-    let looking_for = match cmd {
-        Soup::Reboot | Soup::Nop | Soup::Stdio => PortKind::SoupApp,
-        Soup::Stage0(_) => PortKind::Stage0,
-    };
-
-    let mut port = loop {
-        println!("Looking for soup device...");
-        let (kind, mut port) = loop {
-            match (last_err.as_ref(), get_port()) {
-                (_, Ok((kind, port))) => {
-                    println!(" -> Found {:?}", kind);
-                    break (kind, port);
-                }
-                (Some(FindError::NoneFound), Err(FindError::NoneFound)) => {}
-                (Some(FindError::TooManyFound(of)), Err(FindError::TooManyFound(nf)))
-                    if of == &nf => {}
-                (_, Err(FindError::NoneFound)) => {
-                    println!(" -> No soup devices found!");
-                    println!(" -> Waiting (hit control-c to stop)...");
-                    last_err = Some(FindError::NoneFound);
-                }
-                (_, Err(FindError::TooManyFound(nf))) => {
-                    println!(" -> Too many soup devices found! Remove some.");
-                    println!("   -> Found {:?}", nf);
-                    println!(" -> Waiting (hit control-c to stop)...");
-                    last_err = Some(FindError::TooManyFound(nf));
-                }
-                (_, Err(FindError::Other(e))) => {
-                    println!("unhandled error!");
-                    return Err(e);
-                }
-            }
-            // TODO: some kind of notif on new kinds?
-            std::thread::sleep(Duration::from_millis(100));
-        };
-
-        match (looking_for, kind) {
-            (PortKind::Stage0, PortKind::Stage0) => break port,
-            (PortKind::SoupApp, PortKind::SoupApp) => break port,
-
-            (PortKind::Stage0, PortKind::SoupApp) => {
-                // We found an app, looking for stage 0. Command reset.
-                println!(" -> Commanding reset to return to Stage0 Loader.");
-                send(ToSoup::Control(soup_icd::Control::Reboot), port.deref_mut())?;
-            }
-            (PortKind::SoupApp, PortKind::Stage0) => {
-                println!(" -> Looking for an application, but found a stage0 loader.");
-                println!(" -> Cannot continue.");
-                println!(" -> Try Loading an app with `soup-cli stage0 ...` commands.");
-                return Err("No application found.".into());
-            }
-        }
-    };
 
     match cmd {
         Soup::Reboot => {
             println!("Sending reboot command.");
+            let mut port = connect(PortKind::SoupApp)?;
             send(ToSoup::Control(soup_icd::Control::Reboot), port.deref_mut())
         }
         Soup::Nop => {
             println!("Soup App Connected.");
             Ok(())
-        },
-        Soup::Stage0(shim) => match shim.shim {
-            Stage0::Peek(cmd) => peek(cmd, port.deref_mut()),
-            Stage0::Poke(cmd) => poke(cmd, port.deref_mut()).map(drop),
-            Stage0::Bootload(cmd) => {
-                send(
-                    Request::Bootload {
-                        addr: cmd.address.0,
-                    },
-                    port.deref_mut(),
-                )?;
-                println!("Sent bootload command.");
-                Ok(())
+        }
+        Soup::Stage0(shim) => {
+            let mut port = connect(PortKind::Stage0)?;
+            match shim.shim {
+                Stage0::Peek(cmd) => peek(cmd, port.deref_mut()),
+                Stage0::Poke(cmd) => poke(cmd, port.deref_mut()).map(drop),
+                Stage0::Bootload(cmd) => {
+                    send(
+                        Request::Bootload {
+                            addr: cmd.address.0,
+                        },
+                        port.deref_mut(),
+                    )?;
+                    println!("Sent bootload command.");
+                    Ok(())
+                }
+                Stage0::FlashPeek(cmd) => flash_peek(cmd, port.deref_mut()),
+                Stage0::FlashPoke(cmd) => flash_poke(cmd, port.deref_mut()),
             }
-            Stage0::FlashPeek(cmd) => flash_peek(cmd, port.deref_mut()),
-            Stage0::FlashPoke(cmd) => flash_poke(cmd, port.deref_mut()),
-        },
-        Soup::Stdio => stdio(port.deref_mut()),
+        }
+        Soup::Stdio => {
+            let mut port = connect(PortKind::SoupApp)?;
+            stdio(port.deref_mut())
+        }
+        Soup::Run(Run { elf_path }) => run(elf_path),
     }?;
+
+    Ok(())
+}
+
+fn run(path: String) -> Result<(), Box<dyn Error>> {
+    let load = parse_loadable(path)?;
+    let mut port = connect(PortKind::Stage0)?;
+
+    // Poke elf file into memory
+    poke(
+        Poke {
+            address: cli::Address(load.addr),
+            val: Some(WriteBytes(load.data)),
+            file: None,
+        },
+        port.deref_mut(),
+    )?;
+
+    // Bootload
+    send(Request::Bootload { addr: load.addr }, port.deref_mut())?;
+    println!("Sent bootload command.");
+
+    // Drop the port, reconnect as an app, attach to stdio
+    drop(port);
+
+    let mut port = connect(PortKind::SoupApp)?;
+    stdio(port.deref_mut())?;
 
     Ok(())
 }
@@ -116,7 +102,11 @@ fn flash_poke(cmd: Poke, port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>
     let len = poke(ram_poke, port)?;
 
     // Then, send a ram copy command
-    let copy_cmd = Request::FlashCopy { ram_start: 0x2000_0000, flash_start: cmd.address.0 as usize, len };
+    let copy_cmd = Request::FlashCopy {
+        ram_start: 0x2000_0000,
+        flash_start: cmd.address.0 as usize,
+        len,
+    };
     send(copy_cmd, port)?;
 
     println!(" -> Sent RAM->Flash copy command");
@@ -134,93 +124,10 @@ fn flash_poke(cmd: Poke, port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>
     Ok(())
 }
 
-#[derive(Debug, Copy, Clone)]
-pub enum PortKind {
-    Stage0,
-    SoupApp,
-}
-
-#[derive(Debug)]
-pub enum FindError {
-    NoneFound,
-    TooManyFound(String),
-    Other(Box<dyn Error>),
-}
-
-impl Display for FindError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <Self as core::fmt::Debug>::fmt(self, f)
-    }
-}
-
-impl From<Box<dyn Error>> for FindError {
-    fn from(value: Box<dyn Error>) -> Self {
-        Self::Other(value)
-    }
-}
-
-impl From<&str> for FindError {
-    fn from(value: &str) -> Self {
-        Self::Other(value.into())
-    }
-}
-
-impl From<serialport::Error> for FindError {
-    fn from(value: serialport::Error) -> Self {
-        Self::Other(value.into())
-    }
-}
-
-impl Error for FindError {}
-
-fn get_port() -> Result<(PortKind, Box<dyn SerialPort>), FindError> {
-    let mut ports = vec![];
-
-    for port in serialport::available_ports()? {
-        if let serialport::SerialPortType::UsbPort(serialport::UsbPortInfo {
-            product: Some(prod),
-            ..
-        }) = &port.port_type
-        {
-            match prod.as_str() {
-                // TODO(AJM): Something seems to replace spaces with underscores?
-                "Stage0_Loader" => {
-                    ports.push((PortKind::Stage0, port.clone()));
-                }
-                // TODO(AJM): change the product name
-                x if x.contains("Soup_App") => {
-                    ports.push((PortKind::SoupApp, port.clone()));
-                }
-                _ => {}
-            }
-        }
-    }
-
-    let (kind, dport) = match ports.as_slice() {
-        [] => return Err(FindError::NoneFound),
-        [one] => one,
-        all => {
-            let all = all
-                .iter()
-                .map(|(_kind, p)| p.port_name.clone())
-                .collect::<Vec<_>>();
-            let all = all.join(", ");
-            return Err(FindError::TooManyFound(all));
-        }
-    };
-
-    let port = serialport::new(&dport.port_name, 115200)
-        .timeout(Duration::from_millis(16))
-        .open()?;
-
-    Ok((*kind, port))
-}
-
 fn stdio(port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>> {
     println!("====================");
     println!("Forwarding Stdio... ");
     println!("====================");
-
 
     let mut acc = CobsAccumulator::<512>::new();
 
@@ -237,21 +144,17 @@ fn stdio(port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>> {
             match stdin.read(&mut buf) {
                 Ok(n) => {
                     tx.send((&buf[..n]).to_vec()).unwrap();
-                },
+                }
                 Err(_) => todo!(),
             }
         }
     });
 
-
-
     loop {
         let mut buf = match port.read(&mut raw_buf) {
             Ok(0) => todo!(),
             Ok(n) => &raw_buf[..n],
-            Err(e) if e.kind() == ErrorKind::TimedOut => {
-                &[]
-            }
+            Err(e) if e.kind() == ErrorKind::TimedOut => &[],
             Err(e) => {
                 panic!("{e:?}");
             }
@@ -263,21 +166,21 @@ fn stdio(port: &mut dyn SerialPort) -> Result<(), Box<dyn Error>> {
                 FeedResult::OverFull(new_wind) => {
                     println!("OVERFULL ERR");
                     new_wind
-                },
+                }
                 FeedResult::DeserError(new_wind) => {
                     println!("DESER ERR");
                     new_wind
-                },
+                }
                 FeedResult::Success { data, remaining } => {
                     match data {
                         FromSoup::Stdout(r) => {
                             print!("{}", String::from_utf8_lossy(r.as_slice()));
                             stdout.flush()?;
-                        },
+                        }
                         FromSoup::Stderr(r) => {
                             eprint!("{}", String::from_utf8_lossy(r.as_slice()));
                             stderr.flush()?;
-                        },
+                        }
                         FromSoup::ControlResponse(_r) => todo!(),
                         FromSoup::FromApp(_r) => todo!(),
                         FromSoup::Error(_r) => todo!(),
@@ -438,7 +341,7 @@ fn poke(cmd: Poke, port: &mut dyn SerialPort) -> Result<usize, Box<dyn Error>> {
     let mut idx = cmd.address.0 as usize;
 
     let data = match (cmd.val, cmd.file) {
-        (Some(_val), None) => todo!(),
+        (Some(val), None) => val.0,
         (None, Some(f)) => {
             let mut file = File::open(&f)?;
             let mut buf = Vec::with_capacity(file.metadata()?.len().try_into()?);

--- a/host/soup-cli/src/port.rs
+++ b/host/soup-cli/src/port.rs
@@ -1,0 +1,143 @@
+use std::{time::Duration, error::Error, fmt::Display, ops::DerefMut};
+
+use serialport::SerialPort;
+use soup_icd::ToSoup;
+
+
+pub fn connect(looking_for: PortKind) -> Result<Box<dyn SerialPort>, Box<dyn Error>> {
+    let mut last_err: Option<FindError> = None;
+
+    let port = loop {
+        println!("Looking for soup device...");
+        let (kind, mut port) = loop {
+            match (last_err.as_ref(), get_port()) {
+                (_, Ok((kind, port))) => {
+                    println!(" -> Found {:?}", kind);
+                    break (kind, port);
+                }
+                (Some(FindError::NoneFound), Err(FindError::NoneFound)) => {}
+                (Some(FindError::TooManyFound(of)), Err(FindError::TooManyFound(nf)))
+                    if of == &nf => {}
+                (_, Err(FindError::NoneFound)) => {
+                    println!(" -> No soup devices found!");
+                    println!(" -> Waiting (hit control-c to stop)...");
+                    last_err = Some(FindError::NoneFound);
+                }
+                (_, Err(FindError::TooManyFound(nf))) => {
+                    println!(" -> Too many soup devices found! Remove some.");
+                    println!("   -> Found {:?}", nf);
+                    println!(" -> Waiting (hit control-c to stop)...");
+                    last_err = Some(FindError::TooManyFound(nf));
+                }
+                (_, Err(FindError::Other(e))) => {
+                    println!("unhandled error!");
+                    return Err(e);
+                }
+            }
+            // TODO: some kind of notif on new kinds?
+            std::thread::sleep(Duration::from_millis(100));
+        };
+
+        match (looking_for, kind) {
+            (PortKind::Stage0, PortKind::Stage0) => break port,
+            (PortKind::SoupApp, PortKind::SoupApp) => break port,
+
+            (PortKind::Stage0, PortKind::SoupApp) => {
+                // We found an app, looking for stage 0. Command reset.
+                println!(" -> Commanding reset to return to Stage0 Loader.");
+                crate::send(ToSoup::Control(soup_icd::Control::Reboot), port.deref_mut())?;
+            }
+            (PortKind::SoupApp, PortKind::Stage0) => {
+                println!(" -> Looking for an application, but found a stage0 loader.");
+                println!(" -> Cannot continue.");
+                println!(" -> Try Loading an app with `soup-cli stage0 ...` commands.");
+                return Err("No application found.".into());
+            }
+        }
+    };
+
+    Ok(port)
+}
+
+fn get_port() -> Result<(PortKind, Box<dyn SerialPort>), FindError> {
+    let mut ports = vec![];
+
+    for port in serialport::available_ports()? {
+        if let serialport::SerialPortType::UsbPort(serialport::UsbPortInfo {
+            product: Some(prod),
+            ..
+        }) = &port.port_type
+        {
+            match prod.as_str() {
+                // TODO(AJM): Something seems to replace spaces with underscores?
+                "Stage0_Loader" => {
+                    ports.push((PortKind::Stage0, port.clone()));
+                }
+                // TODO(AJM): change the product name
+                x if x.contains("Soup_App") => {
+                    ports.push((PortKind::SoupApp, port.clone()));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let (kind, dport) = match ports.as_slice() {
+        [] => return Err(FindError::NoneFound),
+        [one] => one,
+        all => {
+            let all = all
+                .iter()
+                .map(|(_kind, p)| p.port_name.clone())
+                .collect::<Vec<_>>();
+            let all = all.join(", ");
+            return Err(FindError::TooManyFound(all));
+        }
+    };
+
+    let port = serialport::new(&dport.port_name, 115200)
+        .timeout(Duration::from_millis(16))
+        .open()?;
+
+    Ok((*kind, port))
+}
+
+
+#[derive(Debug, Copy, Clone)]
+pub enum PortKind {
+    Stage0,
+    SoupApp,
+}
+
+#[derive(Debug)]
+pub enum FindError {
+    NoneFound,
+    TooManyFound(String),
+    Other(Box<dyn Error>),
+}
+
+impl Display for FindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Self as core::fmt::Debug>::fmt(self, f)
+    }
+}
+
+impl From<Box<dyn Error>> for FindError {
+    fn from(value: Box<dyn Error>) -> Self {
+        Self::Other(value)
+    }
+}
+
+impl From<&str> for FindError {
+    fn from(value: &str) -> Self {
+        Self::Other(value.into())
+    }
+}
+
+impl From<serialport::Error> for FindError {
+    fn from(value: serialport::Error) -> Self {
+        Self::Other(value.into())
+    }
+}
+
+impl Error for FindError {}


### PR DESCRIPTION
Adds a `soup-cli run ELF_FILE` command, intended to be used as a cargo runner.

Automatically determines loadable sections, flashes, bootloads, and starts the stdio link.